### PR TITLE
Fix gazebo control errors

### DIFF
--- a/robotiq/robotiq_description/urdf/robotiq_85_gripper.transmission.xacro
+++ b/robotiq/robotiq_description/urdf/robotiq_85_gripper.transmission.xacro
@@ -6,12 +6,12 @@
     <transmission name="${prefix}robotiq_85_left_knuckle_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}robotiq_85_left_knuckle_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
         <!-- <hardwareInterface>EffortJointInterface</hardwareInterface> -->
       </joint>
       <actuator name="${prefix}robotiq_85_left_knuckle_motor">
         <mechanicalReduction>1</mechanicalReduction>
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
         <!-- <hardwareInterface>EfforJointInterface</hardwareInterface> -->
       </actuator>
     </transmission>

--- a/ur5/ur5_description/urdf/ur.transmission.xacro
+++ b/ur5/ur5_description/urdf/ur.transmission.xacro
@@ -6,7 +6,7 @@
     <transmission name="${prefix}shoulder_pan_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_pan_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}shoulder_pan_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -16,7 +16,7 @@
     <transmission name="${prefix}shoulder_lift_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_lift_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}shoulder_lift_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -26,7 +26,7 @@
     <transmission name="${prefix}elbow_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}elbow_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}elbow_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -36,7 +36,7 @@
     <transmission name="${prefix}wrist_1_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_1_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_1_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -46,7 +46,7 @@
     <transmission name="${prefix}wrist_2_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_2_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_2_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -56,7 +56,7 @@
     <transmission name="${prefix}wrist_3_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_3_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
+        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_3_motor">
         <mechanicalReduction>1</mechanicalReduction>

--- a/ur5/ur5_description/urdf/ur5_joint_limited_robot.urdf
+++ b/ur5/ur5_description/urdf/ur5_joint_limited_robot.urdf
@@ -242,7 +242,7 @@
   <transmission name="shoulder_pan_trans">
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="shoulder_pan_joint">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="shoulder_pan_motor">
       <mechanicalReduction>1</mechanicalReduction>
@@ -251,7 +251,7 @@
   <transmission name="shoulder_lift_trans">
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="shoulder_lift_joint">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="shoulder_lift_motor">
       <mechanicalReduction>1</mechanicalReduction>
@@ -260,7 +260,7 @@
   <transmission name="elbow_trans">
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="elbow_joint">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="elbow_motor">
       <mechanicalReduction>1</mechanicalReduction>
@@ -269,7 +269,7 @@
   <transmission name="wrist_1_trans">
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_1_joint">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="wrist_1_motor">
       <mechanicalReduction>1</mechanicalReduction>
@@ -278,7 +278,7 @@
   <transmission name="wrist_2_trans">
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_2_joint">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="wrist_2_motor">
       <mechanicalReduction>1</mechanicalReduction>
@@ -287,7 +287,7 @@
   <transmission name="wrist_3_trans">
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_3_joint">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="wrist_3_motor">
       <mechanicalReduction>1</mechanicalReduction>

--- a/ur5/ur5_gazebo/config/pid_gains.yaml
+++ b/ur5/ur5_gazebo/config/pid_gains.yaml
@@ -1,0 +1,7 @@
+shoulder_pan_joint: {p: 300.0, i: 0.0, d: 0.0}
+shoulder_lift_joint: {p: 300.0, i: 0.0, d: 0.0}
+elbow_joint: {p: 300.0, i: 0.0, d: 0.0}
+wrist_1_joint: {p: 100.0, i: 0.0, d: 0.0}
+wrist_2_joint: {p: 100.0, i: 0.0, d: 0.0}
+wrist_3_joint: {p: 100.0, i: 0.0, d: 0.0}
+robotiq_85_left_knuckle_joint: {p: 100.0, i: 0.0, d: 0.0}

--- a/ur5/ur5_gazebo/launch/ur5_controllers.launch
+++ b/ur5/ur5_gazebo/launch/ur5_controllers.launch
@@ -9,6 +9,9 @@
   <!-- Controllers config -->
   <rosparam file="$(find ur5_gazebo)/controller/ur5gripper_controllers.yaml"
             command="load" />
+  <!-- PID gains for gazebo_ros_control -->
+  <rosparam file="$(find ur5_gazebo)/config/pid_gains.yaml"
+            command="load" />
 
   <!-- Load controllers -->
   <node name="robot_controllers" pkg="controller_manager" type="spawner"


### PR DESCRIPTION
## Summary
- fix gazebo_ros_control warnings by using `hardware_interface/PositionJointInterface`
- load pid gains for gazebo controllers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854d9792bc4832aa3ed3a5432369bb8