### PR TITLE
Limit cans in UR5 project world

### DIFF
--- a/ur5/ur5_gazebo/worlds/ur5_project.world
+++ b/ur5/ur5_gazebo/worlds/ur5_project.world
@@ -116,13 +116,6 @@
     <!-- Soda cans inside bookshelves -->
 
     <!-- Bookshelf 1 -->
-    <model name="can_coke_b1_bottom">
-      <static>true</static>
-      <include>
-        <uri>model://can_coke</uri>
-        <pose>0.2 -0.705 0.86 0 0 3.14</pose>
-      </include>
-    </model>
     <model name="can_pepsi_b1_bottom">
       <static>true</static>
       <include>
@@ -130,95 +123,8 @@
         <pose>0 -0.705 0.86 0 0 3.14</pose>
       </include>
     </model>
-    <model name="can_sprite_b1_bottom">
-      <static>true</static>
-      <include>
-        <uri>model://can_sprite</uri>
-        <pose>-0.2 -0.705 0.86 0 0 3.14</pose>
-      </include>
-    </model>
-
-    <model name="can_coke_b1_middle">
-      <static>true</static>
-      <include>
-        <uri>model://can_coke</uri>
-        <pose>0.2 -0.705 1.18 0 0 3.14</pose>
-      </include>
-    </model>
-    <model name="can_pepsi_b1_middle">
-      <static>true</static>
-      <include>
-        <uri>model://can_pepsi</uri>
-        <pose>0 -0.705 1.18 0 0 3.14</pose>
-      </include>
-    </model>
-    <model name="can_sprite_b1_middle">
-      <static>true</static>
-      <include>
-        <uri>model://can_sprite</uri>
-        <pose>-0.2 -0.705 1.18 0 0 3.14</pose>
-      </include>
-    </model>
-
-    <model name="can_coke_b1_top">
-      <static>true</static>
-      <include>
-        <uri>model://can_coke</uri>
-        <pose>0.2 -0.705 1.48 0 0 3.14</pose>
-      </include>
-    </model>
-    <model name="can_pepsi_b1_top">
-      <static>true</static>
-      <include>
-        <uri>model://can_pepsi</uri>
-        <pose>0 -0.705 1.48 0 0 3.14</pose>
-      </include>
-    </model>
-    <model name="can_sprite_b1_top">
-      <static>true</static>
-      <include>
-        <uri>model://can_sprite</uri>
-        <pose>-0.2 -0.705 1.48 0 0 3.14</pose>
-      </include>
-    </model>
 
     <!-- Bookshelf 2 -->
-    <model name="can_coke_b2_bottom">
-      <static>true</static>
-      <include>
-        <uri>model://can_coke</uri>
-        <pose>-0.708 -0.203 0.86 0 0 1.556</pose>
-      </include>
-    </model>
-    <model name="can_pepsi_b2_bottom">
-      <static>true</static>
-      <include>
-        <uri>model://can_pepsi</uri>
-        <pose>-0.705 -0.003 0.86 0 0 1.556</pose>
-      </include>
-    </model>
-    <model name="can_sprite_b2_bottom">
-      <static>true</static>
-      <include>
-        <uri>model://can_sprite</uri>
-        <pose>-0.702 0.197 0.86 0 0 1.556</pose>
-      </include>
-    </model>
-
-    <model name="can_coke_b2_middle">
-      <static>true</static>
-      <include>
-        <uri>model://can_coke</uri>
-        <pose>-0.708 -0.203 1.18 0 0 1.556</pose>
-      </include>
-    </model>
-    <model name="can_pepsi_b2_middle">
-      <static>true</static>
-      <include>
-        <uri>model://can_pepsi</uri>
-        <pose>-0.705 -0.003 1.18 0 0 1.556</pose>
-      </include>
-    </model>
     <model name="can_sprite_b2_middle">
       <static>true</static>
       <include>
@@ -227,92 +133,12 @@
       </include>
     </model>
 
-    <model name="can_coke_b2_top">
-      <static>true</static>
-      <include>
-        <uri>model://can_coke</uri>
-        <pose>-0.708 -0.203 1.48 0 0 1.556</pose>
-      </include>
-    </model>
-    <model name="can_pepsi_b2_top">
-      <static>true</static>
-      <include>
-        <uri>model://can_pepsi</uri>
-        <pose>-0.705 -0.003 1.48 0 0 1.556</pose>
-      </include>
-    </model>
-    <model name="can_sprite_b2_top">
-      <static>true</static>
-      <include>
-        <uri>model://can_sprite</uri>
-        <pose>-0.702 0.197 1.48 0 0 1.556</pose>
-      </include>
-    </model>
-
     <!-- Bookshelf 3 -->
-    <model name="can_coke_b3_bottom">
-      <static>true</static>
-      <include>
-        <uri>model://can_coke</uri>
-        <pose>-0.2 0.705 0.86 0 0 0</pose>
-      </include>
-    </model>
-    <model name="can_pepsi_b3_bottom">
-      <static>true</static>
-      <include>
-        <uri>model://can_pepsi</uri>
-        <pose>0 0.705 0.86 0 0 0</pose>
-      </include>
-    </model>
-    <model name="can_sprite_b3_bottom">
-      <static>true</static>
-      <include>
-        <uri>model://can_sprite</uri>
-        <pose>0.2 0.705 0.86 0 0 0</pose>
-      </include>
-    </model>
-
-    <model name="can_coke_b3_middle">
-      <static>true</static>
-      <include>
-        <uri>model://can_coke</uri>
-        <pose>-0.2 0.705 1.18 0 0 0</pose>
-      </include>
-    </model>
-    <model name="can_pepsi_b3_middle">
-      <static>true</static>
-      <include>
-        <uri>model://can_pepsi</uri>
-        <pose>0 0.705 1.18 0 0 0</pose>
-      </include>
-    </model>
-    <model name="can_sprite_b3_middle">
-      <static>true</static>
-      <include>
-        <uri>model://can_sprite</uri>
-        <pose>0.2 0.705 1.18 0 0 0</pose>
-      </include>
-    </model>
-
     <model name="can_coke_b3_top">
       <static>true</static>
       <include>
         <uri>model://can_coke</uri>
         <pose>-0.2 0.705 1.48 0 0 0</pose>
-      </include>
-    </model>
-    <model name="can_pepsi_b3_top">
-      <static>true</static>
-      <include>
-        <uri>model://can_pepsi</uri>
-        <pose>0 0.705 1.48 0 0 0</pose>
-      </include>
-    </model>
-    <model name="can_sprite_b3_top">
-      <static>true</static>
-      <include>
-        <uri>model://can_sprite</uri>
-        <pose>0.2 0.705 1.48 0 0 0</pose>
       </include>
     </model>
     <!-- wooden_case sobre cafe_table -->


### PR DESCRIPTION
## Summary
- reduce the number of soda cans in `ur5_project.world` from many to only three
- place one Pepsi, one Sprite and one Coca-Cola on different shelves and levels

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6863876c5d1c832a893e3303b1460106