### PR TITLE
Fix RRT rand_area parameter

### DIFF
--- a/ur5/ur5_gazebo/scripts/rrt_generate_path
+++ b/ur5/ur5_gazebo/scripts/rrt_generate_path
@@ -28,7 +28,10 @@ obstacleList = [
 
 
 
-rrt = RRT3D(start=S, goal=G, obstacle_list=obstacleList, rand_area=[-2, 15])
+# Área de muestreo para el RRT en X, Y y Z
+# Debe especificarse como pares [min, max] para cada eje
+rrt = RRT3D(start=S, goal=G, obstacle_list=obstacleList,
+            rand_area=[[-2.0, 2.0], [-2.0, 2.0], [0.0, 2.0]])
 path = rrt.planning()
 
 # Parámetros

--- a/ur5/ur5_gazebo/scripts/test_diffkine
+++ b/ur5/ur5_gazebo/scripts/test_diffkine
@@ -54,7 +54,9 @@ def main():
 
     S = T[0:3,3] #INICIAL
     G = [0.1, 0.8, 0.1]   #FINAL
-    rrt = RRT3D(start=S, goal=G, obstacle_list=obstacleList, rand_area=[-2, 15])
+    # Área de muestreo para el RRT en X, Y y Z
+    rrt = RRT3D(start=S, goal=G, obstacle_list=obstacleList,
+                rand_area=[[-2.0, 2.0], [-2.0, 2.0], [0.0, 2.0]])
     path = rrt.planning()
     maxIter = 1000
     smoothed_path = path_smoothing_3d(path, maxIter, obstacleList)


### PR DESCRIPTION
## Summary
- fix usage of `rand_area` in rrt_generate_path and test_diffkine

## Testing
- `python3 -m py_compile ur5/ur5_gazebo/scripts/rrt_generate_path ur5/ur5_gazebo/scripts/test_diffkine`

------
https://chatgpt.com/codex/tasks/task_e_686514b9b554832a876bc0c65171f7bf